### PR TITLE
Fix some rounding issues

### DIFF
--- a/cogs/chunithm/tools.py
+++ b/cogs/chunithm/tools.py
@@ -293,7 +293,7 @@ class ToolsCog(commands.Cog, name="Tools"):
     @commands.hybrid_command("rating")
     @logged_prefix_command
     async def rating(
-        self, ctx: Context, rating: Range[float, 1.0, MAX_DIFFICULTY + 2.15]
+        self, ctx: Context, rating: Range[float, 1.0, round(MAX_DIFFICULTY + 2.15, 2)]
     ):
         """Calculate score required to achieve the specified play rating.
 
@@ -307,8 +307,8 @@ class ToolsCog(commands.Cog, name="Tools"):
         res += "\n```Const |   Score\n---------------"
 
         chart_constant_10 = int(rating - 3) * 10
-        rating_10 = rating * 10
-        max_10 = MAX_DIFFICULTY * 10
+        rating_10 = round(rating * 10, 1)
+        max_10 = round(MAX_DIFFICULTY * 10, 1)
 
         if chart_constant_10 < 1:
             chart_constant_10 = 1

--- a/cogs/chunithm/tools.py
+++ b/cogs/chunithm/tools.py
@@ -303,12 +303,13 @@ class ToolsCog(commands.Cog, name="Tools"):
             Play rating you want to achieve
         """
 
+        rating = round(rating, 2)
         res = f"Score required to achieve **{rating}** play rating:"
         res += "\n```Const |   Score\n---------------"
 
         chart_constant_10 = int(rating - 3) * 10
-        rating_10 = round(rating * 10, 1)
-        max_10 = round(MAX_DIFFICULTY * 10, 1)
+        rating_10 = rating * 10
+        max_10 = MAX_DIFFICULTY * 10
 
         if chart_constant_10 < 1:
             chart_constant_10 = 1

--- a/cogs/chunithm/tools.py
+++ b/cogs/chunithm/tools.py
@@ -506,8 +506,8 @@ class ToolsCog(commands.Cog, name="Tools"):
                 target_rating = 1
 
             # Determine min-max const to recommend based on target rating.
-            min_level = target_rating - 2.1501
-            max_level = target_rating
+            min_level = round(target_rating - 2.15, 2)
+            max_level = round(target_rating, 2)
 
             stmt = (
                 select(Chart)

--- a/cogs/chunithm/tools.py
+++ b/cogs/chunithm/tools.py
@@ -232,6 +232,7 @@ class ToolsCog(commands.Cog, name="Tools"):
             Sets the display mode: `default` (Display rating information only) / `aj` (Display OP information for ALL JUSTICE only)
         """
 
+        chart_constant = round(chart_constant, 2)
         res = f"Calculation for chart constant **{chart_constant}**:"
         if mode == "aj":
             separator = "-------------------------"
@@ -304,7 +305,7 @@ class ToolsCog(commands.Cog, name="Tools"):
         """
 
         rating = round(rating, 2)
-        res = f"Score required to achieve **{rating}** play rating:"
+        res = f"Score required to achieve **{rating:.2f}** play rating:"
         res += "\n```Const |   Score\n---------------"
 
         chart_constant_10 = int(rating - 3) * 10

--- a/utils/calculation/rating.py
+++ b/utils/calculation/rating.py
@@ -36,8 +36,8 @@ def calculate_rating(score: int, internal_level: Optional[float]) -> Decimal:
 
 
 def calculate_score_for_rating(rating: float, internal_level: float) -> Optional[int]:
-    rating10000 = int(rating * 10000)
-    internal_level_10000 = int(internal_level * 10000)
+    rating10000 = int(round(rating, 2) * 10000)
+    internal_level_10000 = int(round(internal_level, 2) * 10000)
     coeff = rating10000 - internal_level_10000
 
     req = None

--- a/utils/calculation/rating.py
+++ b/utils/calculation/rating.py
@@ -42,7 +42,7 @@ def calculate_score_for_rating(rating: float, internal_level: float) -> Optional
 
     req = None
 
-    if coeff >= 21_500:
+    if coeff > 21_500:
         req = None
     elif coeff >= 20_000:
         req = 1_007_500 + coeff - 20_000


### PR DESCRIPTION
I love floats
- Fix issue where c>rating doesn't show a chart constant if a score of 1,009,000 is required to achieve that rating (because coeff = 21500 wasn't allowed)
- Fix issue where c>rating 17.85 couldn't be used because 15.7 + 2.15 = 17.849999999999998
- Fix issue where required scores to achieve specific ratings were not properly rounded for some rare cases, like in c>rating 7.27
- Apply similar rounding logic to c>recommend too just in case
- Sanitize input for c>const and c>rating
- Display 2 decimal places for target rating in c>rating