### PR TITLE
fix(build): apply alpine's find library patch for opus to work

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 !/database
 !/dbutils
 !/packages
+!/patches
 !/utils
 !/.python-version
 !/alembic.ini

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ ARG GID=1000
 ARG GIT_SHA=unknown
 
 RUN apk --update-cache upgrade \
-    && apk add --no-interactive mimalloc opus libssl3 libcrypto3 libgcc \
+    && apk add --no-interactive mimalloc opus libssl3 libcrypto3 libgcc patch \
     && apk cache purge \
     && rm -rf /var/cache/apk/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG PYTHON_VERSION=3.13
+ARG PYTHON_BUILD_VERSION=3.13
 
-FROM ghcr.io/astral-sh/uv:0.8.22-python${PYTHON_VERSION}-alpine AS builder
+FROM ghcr.io/astral-sh/uv:0.8.22-python${PYTHON_BUILD_VERSION}-alpine AS builder
 ENV PYTHONOPTIMIZE=1 PYTHONNODEBUGRANGES=1 UV_LINK_MODE=copy
 
 # Disable Python downloads, because we want to use the system interpreter
@@ -33,7 +33,7 @@ RUN python -m compileall -b -x 'database/alembic/versions' . \
     && find . -type f -not -path "*database/alembic/versions*" -name '*.py' -exec rm {} \;
 RUN rm -rf packages/penguin-native/target
 
-FROM python:${PYTHON_VERSION}-alpine
+FROM python:${PYTHON_BUILD_VERSION}-alpine
 
 # Needed for fixing permissions of files created by Docker:
 ARG UID=1000
@@ -47,7 +47,7 @@ RUN apk --update-cache upgrade \
     && rm -rf /var/cache/apk/*
 
 RUN --mount=type=bind,source=patches/python3-musl-find-library.patch,target=python3-musl-find-library.patch \
-    patch "/usr/local/lib/python${PYTHON_VERSION}/ctypes/util.py" python3-musl-find-library.patch
+    patch "/usr/local/lib/python${PYTHON_BUILD_VERSION}/ctypes/util.py" python3-musl-find-library.patch
 
 RUN addgroup -g "${GID}" bot \
     && adduser -D -h "/code" -G bot -u "${UID}" bot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ghcr.io/astral-sh/uv:0.8.22-python3.13-alpine AS builder
+ARG PYTHON_VERSION=3.13
+
+FROM ghcr.io/astral-sh/uv:0.8.22-python${PYTHON_VERSION}-alpine AS builder
 ENV PYTHONOPTIMIZE=1 PYTHONNODEBUGRANGES=1 UV_LINK_MODE=copy
 
 # Disable Python downloads, because we want to use the system interpreter
@@ -31,7 +33,7 @@ RUN python -m compileall -b -x 'database/alembic/versions' . \
     && find . -type f -not -path "*database/alembic/versions*" -name '*.py' -exec rm {} \;
 RUN rm -rf packages/penguin-native/target
 
-FROM python:3.13-alpine
+FROM python:${PYTHON_VERSION}-alpine
 
 # Needed for fixing permissions of files created by Docker:
 ARG UID=1000
@@ -43,6 +45,9 @@ RUN apk --update-cache upgrade \
     && apk add --no-interactive mimalloc opus libssl3 libcrypto3 libgcc \
     && apk cache purge \
     && rm -rf /var/cache/apk/*
+
+RUN --mount=type=bind,source=patches/python3-musl-find-library.patch,target=python3-musl-find-library.patch \
+    patch "/usr/local/lib/python${PYTHON_VERSION}/ctypes/util.py" python3-musl-find-library.patch
 
 RUN addgroup -g "${GID}" bot \
     && adduser -D -h "/code" -G bot -u "${UID}" bot

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN python -m compileall -b -x 'database/alembic/versions' . \
 RUN rm -rf packages/penguin-native/target
 
 FROM python:${PYTHON_BUILD_VERSION}-alpine
+ARG PYTHON_BUILD_VERSION
 
 # Needed for fixing permissions of files created by Docker:
 ARG UID=1000

--- a/patches/python3-musl-find-library.patch
+++ b/patches/python3-musl-find-library.patch
@@ -1,0 +1,45 @@
+diff -ru Python-2.7.12.orig/Lib/ctypes/util.py Python-2.7.12/Lib/ctypes/util.py
+--- Python-2.7.12.orig/Lib/ctypes/util.py	2016-06-26 00:49:30.000000000 +0300
++++ Python-2.7.12/Lib/ctypes/util.py	2016-11-03 16:05:46.954665040 +0200
+@@ -204,6 +204,41 @@
+         def find_library(name, is64 = False):
+             return _get_soname(_findLib_crle(name, is64) or _findLib_gcc(name))
+ 
++    elif True:
++
++        # Patched for Alpine Linux / musl - search manually system paths
++        def _is_elf(filepath):
++            try:
++                with open(filepath, 'rb') as fh:
++                    return fh.read(4) == b'\x7fELF'
++            except:
++                return False
++
++        def find_library(name):
++            from glob import glob
++            # absolute name?
++            if os.path.isabs(name):
++                return name
++            # special case for libm, libcrypt and libpthread and musl
++            if name in ['m', 'crypt', 'pthread']:
++                name = 'c'
++            elif name in ['libm.so', 'libcrypt.so', 'libpthread.so']:
++                name = 'libc.so'
++            # search in standard locations (musl order)
++            paths = ['/lib', '/usr/local/lib', '/usr/lib']
++            if 'LD_LIBRARY_PATH' in os.environ:
++                paths = os.environ['LD_LIBRARY_PATH'].split(':') + paths
++            for d in paths:
++                f = os.path.join(d, name)
++                if _is_elf(f):
++                    return os.path.basename(f)
++
++                prefix = os.path.join(d, 'lib'+name)
++                for suffix in ['.so', '.so.*']:
++                    for f in glob('{0}{1}'.format(prefix, suffix)):
++                        if _is_elf(f):
++                            return os.path.basename(f)
++
+     else:
+ 
+         def _findSoname_ldconfig(name):


### PR DESCRIPTION
`ctypes.util.find_library` doesn't work on musl Linux distributions like Alpine (https://github.com/python/cpython/issues/65821). The workaround is to patch `ctypes.util` itself, so we're doing that. The patch is vendored from Alpine Linux: https://git.alpinelinux.org/aports/tree/main/python3/musl-find_library.patch

