### PR TITLE
fix: remove cchardet from speedups extras

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
         run: "uv run basedpyright"
 
       - name: "Run tests"
-        run: "uv run pytest -v --html=report.html --self-contained-html tests"
+        run: "uv run pytest -Werror -v --html=report.html --self-contained-html tests"
 
       - name: "Upload test report"
         if: "always()"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ speedup = [
     "lxml>=5.3.0",
     "uvloop>=0.21.0; sys_platform != 'win32' and implementation_name == 'cpython'",
     "winloop>=0.1.6; sys_platform == 'win32' and implementation_name == 'cpython'",
-    "zstandard>=0.23.0",
+    "zstandard>=0.23.0; python_version <= '3.13'",
     "aiodns>=3.2.0; sys_platform != 'win32'",
     "ciso8601>=2.3.2",
     "penguin-native",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,10 @@ requires-python = ">= 3.12"
 
 [project.optional-dependencies]
 speedup = [
-    "faust-cchardet>=2.1.19",
     "brotli>=1.1.0",
     "lxml>=5.3.0",
-    "uvloop>=0.21.0; sys_platform != 'win32'",
-    "winloop>=0.1.6; sys_platform == 'win32'",
+    "uvloop>=0.21.0; sys_platform != 'win32' and implementation_name == 'cpython'",
+    "winloop>=0.1.6; sys_platform == 'win32' and implementation_name == 'cpython'",
     "zstandard>=0.23.0",
     "aiodns>=3.2.0; sys_platform != 'win32'",
     "ciso8601>=2.3.2",

--- a/uv.lock
+++ b/uv.lock
@@ -308,7 +308,7 @@ speedup = [
     { name = "penguin-native" },
     { name = "uvloop", marker = "implementation_name == 'cpython' and sys_platform != 'win32'" },
     { name = "winloop", marker = "implementation_name == 'cpython' and sys_platform == 'win32'" },
-    { name = "zstandard" },
+    { name = "zstandard", marker = "python_full_version < '3.14'" },
 ]
 
 [package.dev-dependencies]
@@ -358,7 +358,7 @@ requires-dist = [
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2024.2" },
     { name = "uvloop", marker = "implementation_name == 'cpython' and sys_platform != 'win32' and extra == 'speedup'", specifier = ">=0.21.0" },
     { name = "winloop", marker = "implementation_name == 'cpython' and sys_platform == 'win32' and extra == 'speedup'", specifier = ">=0.1.6" },
-    { name = "zstandard", marker = "extra == 'speedup'", specifier = ">=0.23.0" },
+    { name = "zstandard", marker = "python_full_version < '3.14' and extra == 'speedup'", specifier = ">=0.23.0" },
 ]
 provides-extras = ["speedup"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -304,11 +304,10 @@ speedup = [
     { name = "aiodns", marker = "sys_platform != 'win32'" },
     { name = "brotli" },
     { name = "ciso8601" },
-    { name = "faust-cchardet" },
     { name = "lxml" },
     { name = "penguin-native" },
-    { name = "uvloop", marker = "sys_platform != 'win32'" },
-    { name = "winloop", marker = "sys_platform == 'win32'" },
+    { name = "uvloop", marker = "implementation_name == 'cpython' and sys_platform != 'win32'" },
+    { name = "winloop", marker = "implementation_name == 'cpython' and sys_platform == 'win32'" },
     { name = "zstandard" },
 ]
 
@@ -345,7 +344,6 @@ requires-dist = [
     { name = "discord-ext-songbird", git = "https://github.com/beer-psi/discord-ext-songbird.git" },
     { name = "discord-ext-track-edits", specifier = ">=0.1.2" },
     { name = "discord-py", specifier = ">=2.6.3" },
-    { name = "faust-cchardet", marker = "extra == 'speedup'", specifier = ">=2.1.19" },
     { name = "hishel", specifier = ">=0.1.3" },
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "httpx-aiohttp", editable = "packages/httpx-aiohttp" },
@@ -358,8 +356,8 @@ requires-dist = [
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.36" },
     { name = "structlog", specifier = ">=25.2.0" },
     { name = "tzdata", marker = "sys_platform == 'win32'", specifier = ">=2024.2" },
-    { name = "uvloop", marker = "sys_platform != 'win32' and extra == 'speedup'", specifier = ">=0.21.0" },
-    { name = "winloop", marker = "sys_platform == 'win32' and extra == 'speedup'", specifier = ">=0.1.6" },
+    { name = "uvloop", marker = "implementation_name == 'cpython' and sys_platform != 'win32' and extra == 'speedup'", specifier = ">=0.21.0" },
+    { name = "winloop", marker = "implementation_name == 'cpython' and sys_platform == 'win32' and extra == 'speedup'", specifier = ">=0.1.6" },
     { name = "zstandard", marker = "extra == 'speedup'", specifier = ">=0.23.0" },
 ]
 provides-extras = ["speedup"]
@@ -474,12 +472,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/6f/00/ec765ba7d5e16dfc0
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/4e/05fcecd452bde37fba8e9545c318099cbb8bad7f496b6d9322fa2b88f92f/discord_py-2.6.3-py3-none-any.whl", hash = "sha256:69835269d73d9889a2f0efff4c91264a18998db0fdc4295a3c886fe9196dea4e", size = 1208828, upload-time = "2025-08-31T19:30:21.48Z" },
 ]
-
-[[package]]
-name = "faust-cchardet"
-version = "2.1.19"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e9/53/2125d17d7c2a14b76303bf5c3c5db35ea8e4b8a14817bb191c601d67e288/faust-cchardet-2.1.19.tar.gz", hash = "sha256:f89386297cde0c8e0f5e21464bc2d6d0e4a4fc1b1d77cdb238ca24d740d872e0", size = 678871, upload-time = "2023-08-09T16:34:28.643Z" }
 
 [[package]]
 name = "frozenlist"


### PR DESCRIPTION
It turns out `aiohttp` [stopped using charset detection](https://github.com/aio-libs/aiohttp/commit/675579699422680607108a7dd68c85ec5284220c) long ago, so the dependency was basically doing nothing.