### PR TITLE
feat: add pfp/banners to kamaitachi profile cards

### DIFF
--- a/cogs/chunithm/profile.py
+++ b/cogs/chunithm/profile.py
@@ -16,6 +16,7 @@ from chunithm_net.exceptions import ChuniNetError
 from chunithm_net.models.enums import SkillClass
 from database.models import UserConfig
 from utils import flags, json_loads
+from utils.config import config
 from utils.context import PenguinContext
 from utils.converters import MemberOrUserConverter
 from utils.logging import logged_app_command, logged_prefix_command
@@ -195,6 +196,8 @@ class ProfileCog(commands.Cog, name="Profile"):
 
             user_id = data["body"]["id"]
             username = data["body"]["username"]
+            custom_banner_location = data["body"]["customBannerLocation"]
+            custom_pfp_location = data["body"]["customPfpLocation"]
 
             resp = await client.get(
                 "https://kamai.tachi.ac/api/v1/users/me/games/chunithm/Single"
@@ -212,6 +215,22 @@ class ProfileCog(commands.Cog, name="Profile"):
             color=0xCA1961,
             url=f"https://kamai.tachi.ac/u/{username}/games/chunithm/Single",
         )
+
+        if (
+            config.web.enable
+            and config.web.base_url is not None
+            and "localhost" not in config.web.base_url
+            and "127.0.0.1" not in config.web.base_url
+        ):
+            if custom_banner_location is not None:
+                embed.set_image(
+                    url=f"{config.web.base_url}/kamaitachi/users/{user_id}/banner/{custom_banner_location}"
+                )
+            if custom_pfp_location is not None:
+                embed.set_thumbnail(
+                    url=f"{config.web.base_url}/kamaitachi/users/{user_id}/pfp/{custom_pfp_location}"
+                )
+
         description = ""
 
         if "dan" in stats["gameStats"]["classes"]:

--- a/cogs/web.py
+++ b/cogs/web.py
@@ -2,6 +2,7 @@ import asyncio
 import sys
 from datetime import UTC, datetime
 from html import escape
+from io import BytesIO
 from typing import TYPE_CHECKING, override
 
 import aiohttp
@@ -11,6 +12,7 @@ from aiohttp.web import Application
 from async_lru import alru_cache
 from discord.ext import commands
 from discord.utils import oauth_url
+from PIL import Image, UnidentifiedImageError
 from sqlalchemy import select
 from sqlalchemy.orm import joinedload
 
@@ -47,8 +49,9 @@ async def kamaitachi_oauth(request: web.Request) -> web.Response:
             reason="Some options are not configured. Yell at the bot owner."
         )
 
-    session: ClientSession = request.config_dict["session"] or ClientSession()
+    session: ClientSession = request.config_dict["session"]
     params = request.query
+
     if "code" not in params or "context" not in params:
         raise web.HTTPBadRequest(reason="Missing parameters")
 
@@ -109,6 +112,57 @@ async def kamaitachi_oauth(request: web.Request) -> web.Response:
                 )
 
     return web.Response(text=message, content_type="text/plain")
+
+
+@router.get(r"/kamaitachi/users/{user_id:\d+}/{image_type:(pfp|banner)}/{filename}")
+async def kamaitachi_user_image(request: web.Request) -> web.Response:
+    user_id = int(request.match_info["user_id"])
+    image_type = request.match_info["image_type"]
+    filename = request.match_info["filename"]
+
+    session: ClientSession = request.config_dict["session"]
+
+    kamai_cdn_url = (
+        f"https://cdn-kamai.tachi.ac/users/{user_id}/{image_type}-{filename}"
+    )
+
+    # Kamaitachi profile pictures and banners are named using the image's
+    # SHA256 hash, so an image link should be as good as permanent (until the
+    # user switches to another profile picture).
+    # This also means that they can be used as ETag identifiers. If anyone
+    # sends an If-None-Match header, they should already have the image
+    # cached in their system.
+    # Though we send a HEAD just to be sure.
+    if "If-None-Match" in request.headers:
+        async with session.head(kamai_cdn_url) as resp:
+            if resp.ok:
+                return web.Response(status=304)
+
+    async with session.get(kamai_cdn_url) as resp:
+        body = await resp.read()
+        web_resp = web.Response(
+            body=body,
+            status=resp.status,
+            headers=resp.headers,
+        )
+
+        if not resp.ok:
+            return web_resp
+
+    web_resp.headers["Cache-Control"] = "public, max-age=315360000"
+    web_resp.headers["ETag"] = f'"{filename}"'
+
+    try:
+        image = await asyncio.to_thread(Image.open, BytesIO(body))
+    except UnidentifiedImageError:
+        return web_resp
+
+    if image.format is None:
+        return web_resp
+
+    web_resp.content_type = Image.MIME[image.format]
+
+    return web_resp
 
 
 @router.get("/invite")


### PR DESCRIPTION
the proxy is because kamaitachi cdn serves everything as `application/octet-stream`, which discord doesn't like