### PR TITLE
fix: add missing weekly bonus icons

### DIFF
--- a/bot.example.ini
+++ b/bot.example.ini
@@ -79,10 +79,13 @@ token = <your bot token>
 # b =
 # c =
 # d =
-# bonus_icon_chance =
 # bonus_icon_map =
-# bonus_icon_gamepoint =
 # bonus_icon_exp =
+# bonus_icon_point =
+# bonus_icon_chance =
+# bonus_icon_critical =
+# bonus_icon_gamepoint =
+# bonus_icon_selection =
 
 [legal]
 # Link to the bot's privacy policy.

--- a/utils/config.py
+++ b/utils/config.py
@@ -105,10 +105,13 @@ class IconsConfig:
         "b",
         "c",
         "d",
-        "bonus_icon_chance",
         "bonus_icon_map",
-        "bonus_icon_gamepoint",
         "bonus_icon_exp",
+        "bonus_icon_point",
+        "bonus_icon_chance",
+        "bonus_icon_critical",
+        "bonus_icon_gamepoint",
+        "bonus_icon_selection",
     )
 
     def __init__(self, section: "SectionProxy") -> None:


### PR DESCRIPTION
Funnily enough I think `bonus_icon_critical` is for duel criticals, which has been removed since LUMINOUS, but they still keep the file around on CHUNITHM-NET.

For reference, here's all the bonus icons:

| Name                 | Icon |
|----------------------|------|
| bonus_icon_map       | <img width="50" height="42" alt="bonus_icon_map" src="https://github.com/user-attachments/assets/ebc49f3d-d4fc-4710-8603-f3242ff46ec1" /> |
| bonus_icon_exp       | <img width="50" height="42" alt="bonus_icon_exp" src="https://github.com/user-attachments/assets/c7ba2806-d83d-45f2-97e6-43f540686076" /> |
| bonus_icon_point     | <img width="50" height="42" alt="bonus_icon_point" src="https://github.com/user-attachments/assets/f5475e83-a83f-4c55-a432-0d19478d0fe8" /> |
| bonus_icon_chance    | <img width="50" height="42" alt="bonus_icon_chance" src="https://github.com/user-attachments/assets/73911342-8cbd-4aee-89ff-011847d810c1" /> |
| bonus_icon_critical  | <img width="50" height="42" alt="bonus_icon_critical" src="https://github.com/user-attachments/assets/5bad994c-97a6-41ab-ade6-750148661bed" /> |
| bonus_icon_gamepoint | <img width="50" height="42" alt="bonus_icon_gamepoint" src="https://github.com/user-attachments/assets/d1fd2b36-5b0c-45db-a3cd-93d42be86623" /> |
| bonus_icon_selection | <img width="50" height="42" alt="bonus_icon_selection" src="https://github.com/user-attachments/assets/2053d1b2-185d-4955-b4d4-9950368cb097" /> |

