### PR TITLE
fix(profile): Try to add a file extension for Kamaitachi pfp/banners

### DIFF
--- a/cogs/chunithm/profile.py
+++ b/cogs/chunithm/profile.py
@@ -6,6 +6,8 @@ from io import BytesIO
 from typing import TYPE_CHECKING, Literal, override
 
 import discord
+import httpx
+import magic
 from discord import app_commands
 from discord.ext import commands
 from discord.ext.commands import Context
@@ -132,6 +134,35 @@ def render_avatar(items: dict[str, bytes]) -> BytesIO:
     return buffer
 
 
+async def guess_mime_type(response: httpx.Response) -> str:
+    data = BytesIO()
+
+    async for chunk in response.aiter_bytes():
+        if data.tell() == 0:
+            # some simple and common formats can be checked first without
+            # calling into libmagic
+            fourcc = chunk[:4]
+
+            if fourcc == b"GIF8":
+                return "image/gif"
+
+            if fourcc == b"\x89PNG":
+                return "image/png"
+
+            if fourcc[:3] == b"\xff\xd8\xff" and fourcc[3] in (0xDB, 0xE0, 0xE1, 0xEE):
+                return "image/jpeg"
+
+            if fourcc == b"RIFF" and fourcc[8:12] == b"WEBP":
+                return "image/webp"
+
+        data.write(chunk)
+
+        if data.tell() >= 2048:
+            break
+
+    return magic.from_buffer(data.getvalue(), mime=True)
+
+
 class ProfileCog(commands.Cog, name="Profile"):
     def __init__(self, bot: "ChuniBot") -> None:
         self.bot = bot
@@ -198,6 +229,24 @@ class ProfileCog(commands.Cog, name="Profile"):
             username = data["body"]["username"]
             custom_banner_location = data["body"]["customBannerLocation"]
             custom_pfp_location = data["body"]["customPfpLocation"]
+
+            # Discord really doesn't like image files without extensions, hence
+            # this stupid hack.
+            if custom_banner_location is not None:
+                async with client.stream_banner(
+                    user_id, custom_banner_location
+                ) as response:
+                    mime = await guess_mime_type(response)
+
+                    if mime.startswith("image/"):
+                        custom_banner_location += f".{mime[6:]}"
+
+            if custom_pfp_location is not None:
+                async with client.stream_pfp(user_id, custom_pfp_location) as response:
+                    mime = await guess_mime_type(response)
+
+                    if mime.startswith("image/"):
+                        custom_pfp_location += f".{mime[6:]}"
 
             resp = await client.get(
                 "https://kamai.tachi.ac/api/v1/users/me/games/chunithm/Single"

--- a/cogs/web.py
+++ b/cogs/web.py
@@ -3,6 +3,7 @@ import sys
 from datetime import UTC, datetime
 from html import escape
 from io import BytesIO
+from pathlib import Path
 from typing import TYPE_CHECKING, override
 
 import aiohttp
@@ -123,7 +124,7 @@ async def kamaitachi_user_image(request: web.Request) -> web.Response:
     session: ClientSession = request.config_dict["session"]
 
     kamai_cdn_url = (
-        f"https://cdn-kamai.tachi.ac/users/{user_id}/{image_type}-{filename}"
+        f"https://cdn-kamai.tachi.ac/users/{user_id}/{image_type}-{Path(filename).stem}"
     )
 
     # Kamaitachi profile pictures and banners are named using the image's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "audioop-lts>=0.2.2; python_version >= '3.13'",
     "discord-ext-songbird",
     "httpx-aiohttp",
+    "python-magic>=0.4.27",
 ]
 readme = "README.md"
 requires-python = ">= 3.12"

--- a/utils/kamaitachi.py
+++ b/utils/kamaitachi.py
@@ -1,4 +1,5 @@
 import urllib.parse
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from decimal import Decimal
 from typing import Any, Generic, Literal, TypeVar
@@ -457,6 +458,34 @@ class KamaitachiClient:
 
     async def get(self, url: str) -> httpx.Response:
         return await self._client.get(url)
+
+    @asynccontextmanager
+    async def stream_pfp(self, user_id: int, custom_pfp_location: str):
+        request = self._client.build_request(
+            "GET",
+            f"https://cdn-kamai.tachi.ac/users/{user_id}/pfp-{custom_pfp_location}",
+        )
+        del request.headers["Authorization"]
+
+        response = await self._client.send(request=request, stream=True)
+        try:
+            yield response
+        finally:
+            await response.aclose()
+
+    @asynccontextmanager
+    async def stream_banner(self, user_id: int, custom_banner_location: str):
+        request = self._client.build_request(
+            "GET",
+            f"https://cdn-kamai.tachi.ac/users/{user_id}/banner-{custom_banner_location}",
+        )
+        del request.headers["Authorization"]
+
+        response = await self._client.send(request=request, stream=True)
+        try:
+            yield response
+        finally:
+            await response.aclose()
 
     async def chunithm_profile(self) -> httpx.Response:
         return await self._client.get(

--- a/uv.lock
+++ b/uv.lock
@@ -293,6 +293,7 @@ dependencies = [
     { name = "msgspec" },
     { name = "pillow" },
     { name = "platformdirs" },
+    { name = "python-magic" },
     { name = "rapidfuzz" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
@@ -352,6 +353,7 @@ requires-dist = [
     { name = "penguin-native", marker = "extra == 'speedup'", editable = "packages/penguin-native" },
     { name = "pillow", specifier = ">=11.0.0" },
     { name = "platformdirs", specifier = ">=4.3.8" },
+    { name = "python-magic", specifier = ">=0.4.27" },
     { name = "rapidfuzz", specifier = ">=3.10.0" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.36" },
     { name = "structlog", specifier = ">=25.2.0" },
@@ -977,6 +979,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a6/85/8c969f8bec4e559f8f2b958a15229a35495f5b4ce499f6b865eac54b878d/pytest_metadata-3.1.1.tar.gz", hash = "sha256:d2a29b0355fbc03f168aa96d41ff88b1a3b44a3b02acbe491801c98a048017c8", size = 9952, upload-time = "2024-02-12T19:38:44.887Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3e/43/7e7b2ec865caa92f67b8f0e9231a798d102724ca4c0e1f414316be1c1ef2/pytest_metadata-3.1.1-py3-none-any.whl", hash = "sha256:c8e0844db684ee1c798cfa38908d20d67d0463ecb6137c72e91f418558dd5f4b", size = 11428, upload-time = "2024-02-12T19:38:42.531Z" },
+]
+
+[[package]]
+name = "python-magic"
+version = "0.4.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/db/0b3e28ac047452d079d375ec6798bf76a036a08182dbb39ed38116a49130/python-magic-0.4.27.tar.gz", hash = "sha256:c1ba14b08e4a5f5c31a302b7721239695b2f0f058d125bd5ce1ee36b9d9d3c3b", size = 14677, upload-time = "2022-06-07T20:16:59.508Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/73/9f872cb81fc5c3bb48f7227872c28975f998f3e7c2b1c16e95e6432bbb90/python_magic-0.4.27-py2.py3-none-any.whl", hash = "sha256:c212960ad306f700aa0d01e5d7a325d20548ff97eb9920dcd29513174f0294d3", size = 13840, upload-time = "2022-06-07T20:16:57.763Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Discord's media proxy *really* does not want to use GIFs. You have to have a `.gif` extension **on top of** sending the `image/gif` content type. This PR:
- Allows the Kamaitachi pfp/banner proxy to accept arbitrary file extensions...
- ...which enables the bot to try and fetch the first few bytes of the profile picture to guess its extension, using a combination of manual magic bytes checking and `python-magic`.

An unfortunate consequence of this is that we're always going to be hitting the Tachi CDN, even when the pfp link is technically immutable (meaning you should only have to fetch the file once).