### PR TITLE
renovate: do not automatically update ruff/basedpyright

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,5 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": ["config:recommended"],
+    "ignoreDeps": ["ruff", "basedpyright", "python"]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,5 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": ["config:recommended"],
-    "ignoreDeps": ["ruff", "basedpyright", "python"]
+    "ignoreDeps": ["ruff", "basedpyright"]
 }


### PR DESCRIPTION
We **pin** the version using `==` for a reason. I don't have time to keep up with lint rules and typechecking rule changes. 