### PR TITLE
fix(networks): support phoenix titles

### DIFF
--- a/chuni_penguin/networks/chunithm_net/parser.py
+++ b/chuni_penguin/networks/chunithm_net/parser.py
@@ -99,10 +99,10 @@ def parse_title(element: Tag) -> Title | None:
         return None
 
     title_background_url: str = title_background_url_match.group("url")
-    title_background_filename = title_background_url.split("/")[-1].split(".")[0]
+    title_background_filename = title_background_url.split("/")[-1]
 
     if title_background_filename.startswith("honor_bg_"):
-        title_rarity = title_background_filename[9:]
+        title_rarity = title_background_filename.split(".")[0][9:]
 
         if title_rarity == "noSet":
             return None

--- a/chuni_penguin/networks/chunithm_net/parser.py
+++ b/chuni_penguin/networks/chunithm_net/parser.py
@@ -99,10 +99,10 @@ def parse_title(element: Tag) -> Title | None:
         return None
 
     title_background_url: str = title_background_url_match.group("url")
-    title_background_filename = title_background_url.split("/")[-1]
+    title_background_filename = title_background_url.split("/")[-1].split(".")[0]
 
     if title_background_filename.startswith("honor_bg_"):
-        title_rarity = extract_last_part(title_background_filename)
+        title_rarity = title_background_filename[9:]
 
         if title_rarity == "noSet":
             return None
@@ -116,16 +116,17 @@ def parse_title(element: Tag) -> Title | None:
             raise ValueError(msg)
 
         title_content = title_content_elem.get_text()
+        title_rarity = Rarity(title_rarity)
     elif special_title := SPECIAL_TITLES.get(title_background_filename):
         title_content = special_title.content
-        title_rarity = special_title.rarity
+        title_rarity = Rarity(special_title.rarity)
     else:
         _logger.warning(
             "Ignoring unknown special title with URL %s", title_background_url
         )
         return None
 
-    return Title(content=title_content, rarity=Rarity(title_rarity))
+    return Title(content=title_content, rarity=title_rarity)
 
 
 def parse_player_card_and_avatar(soup: BeautifulSoup):

--- a/chuni_penguin/networks/types/enums.py
+++ b/chuni_penguin/networks/types/enums.py
@@ -20,6 +20,10 @@ class Rarity(Enum):
     staff = "staff"
     maimai = "maimai"
 
+    phoenix_gold = "phoenix_g"
+    phoenix_platinum = "phoenix_p"
+    phoenix_rainbow = "phoenix_r"
+
     version1 = "version1"
     version2 = "version2"
     version3 = "version3"


### PR DESCRIPTION
Phoenix Dress titles were introduced in VERSE to replace the (honestly tacky) titles of Irodorimidori girls that had more hearts the more character ranks you achieved with her.

https://info-chunithm.sega.jp/8930/

<img width="988" height="596" alt="image" src="https://github.com/user-attachments/assets/bcfc08af-138c-4ec1-aa0a-b7a792ed2633" />

It's not shown in the changelog above, but here's what the titles look like:

|                  |                                                                        |
|------------------|------------------------------------------------------------------------|
| Phoenix Gold     | ![](https://chunithm-net-eng.com/mobile/images/honor_bg_phoenix_g.png) |
| Phoenix Platinum | ![](https://chunithm-net-eng.com/mobile/images/honor_bg_phoenix_p.png) |
| Phoenix Rainbow  | ![](https://chunithm-net-eng.com/mobile/images/honor_bg_phoenix_r.png) |