### PR TITLE
Support level ranges on c>random and c>find

### DIFF
--- a/chuni_penguin/cogs/chunithm/records.py
+++ b/chuni_penguin/cogs/chunithm/records.py
@@ -1868,9 +1868,9 @@ class RecordsCog(commands.Cog, name="Records"):
             internal_level: float | None = None
 
             if level is not None:
-                level_folder, internal_level = await LevelConverter().convert(
-                    ctx, level
-                )
+                level_data = await LevelConverter().convert(ctx, level)
+                level_folder = level_data.level
+                internal_level = level_data.const
 
             if level_folder is not None and client.SUPPORTS_PERSONAL_BESTS_BY_LEVEL:
                 records = await client.get_personal_bests_by_level(level_folder)

--- a/chuni_penguin/cogs/chunithm/search.py
+++ b/chuni_penguin/cogs/chunithm/search.py
@@ -14,7 +14,13 @@ from sqlalchemy.orm import joinedload
 from chuni_penguin.config import config
 from chuni_penguin.constants import SIMILARITY_THRESHOLD
 from chuni_penguin.context import PenguinContext
-from chuni_penguin.converters import AliasNameConverter, AliasNameTransformer
+from chuni_penguin.converters import (
+    AliasNameConverter,
+    AliasNameTransformer,
+    Level,
+    LevelRange,
+    LevelRangeConverter,
+)
 from chuni_penguin.database import Alias, Chart, Course, Song
 from chuni_penguin.logging import logged_app_command, logged_prefix_command
 from chuni_penguin.networks.errors import NetworkError
@@ -73,31 +79,42 @@ class SearchCog(commands.Cog, name="Search"):
 
     @commands.hybrid_command("find")
     @logged_prefix_command
-    async def find(self, ctx: Context, level: str):
+    async def find(
+        self,
+        ctx: Context,
+        level: Annotated[Level | LevelRange, LevelRangeConverter],
+    ):
         """Find charts by level or chart constant.
 
         Parameters
         ----------
-        query: float
-            Chart constant to search for.
+        level: Level | LevelRange
+            Level (13+), chart constant (13.5), or level range (13.2-13.7) to search for.
         """
 
         stmt = (
             select(Chart)
             .options(joinedload(Chart.sdvxin_chart_view), joinedload(Chart.song))
             .join(Song, Chart.song)
-            .order_by(Song.title)
+            .order_by(Chart.const, Song.title)
         )
 
-        try:
-            if "." in level:
-                query_level = float(level)
-                stmt = stmt.where(Chart.const == query_level)
-            else:
-                stmt = stmt.where(Chart.level == level)
-        except ValueError:
-            msg = "Please enter a valid level or chart constant."
-            raise commands.BadArgument(msg) from None
+        if isinstance(level, LevelRange):
+            if level.min_level is not None:
+                stmt = stmt.where(
+                    Chart.const
+                    >= (level.min_level.const or level.min_level.inferred_const)
+                )
+
+            if level.max_level is not None:
+                stmt = stmt.where(
+                    Chart.const
+                    <= (level.max_level.const or level.max_level.inferred_max_const)
+                )
+        elif level.const is not None:
+            stmt = stmt.where(Chart.const == level.const)
+        else:
+            stmt = stmt.where(Chart.level == level.level)
 
         async with ctx.typing(), self.bot.begin_db_session() as session:
             charts = (await session.execute(stmt)).scalars().all()

--- a/chuni_penguin/cogs/chunithm/tools.py
+++ b/chuni_penguin/cogs/chunithm/tools.py
@@ -26,7 +26,12 @@ from chuni_penguin.calculation import (
 from chuni_penguin.config import config
 from chuni_penguin.constants import MAX_DIFFICULTY
 from chuni_penguin.context import PenguinContext
-from chuni_penguin.converters import AliasNameConverter, DifficultyConverter
+from chuni_penguin.converters import (
+    AliasNameConverter,
+    DifficultyConverter,
+    LevelRange,
+    LevelRangeConverter,
+)
 from chuni_penguin.database import Chart, Song
 from chuni_penguin.logging import logged_prefix_command
 from chuni_penguin.networks.consts import KEY_PLAY_RATING
@@ -347,8 +352,9 @@ class ToolsCog(commands.Cog, name="Tools"):
         Parameters
         ----------
         level: str
-            Level to search for. Can be a level (13+), a chart constant (13.5), or a
-            course class (`i`, `ii`, `iii`, `iv`, `v`, `inf`, `random`, `wallpanic`).
+            Level to search for. Can be a level (13+), a chart constant (13.5), a level
+            range (14.0-14.8), or a course class (`i`, `ii`, `iii`, `iv`, `v`, `inf`,
+            `random`, `wallpanic`).
         count: int
             Number of charts to return. Must be between 1 and 10. Not respected when
             rolling a random course.
@@ -447,20 +453,26 @@ class ToolsCog(commands.Cog, name="Tools"):
                         charts.append(chart)
             else:
                 content = None
-                try:
-                    if "." in level:
-                        query_level = float(level)
-                        stmt = stmt.limit(count).where(Chart.const == query_level)
-                    elif (
-                        level.endswith("+") and level[:-1].isnumeric()
-                    ) or level.isnumeric():
-                        stmt = stmt.limit(count).where(Chart.level == level)
-                    else:
-                        msg = "Please enter a valid level or chart constant."
-                        raise commands.BadArgument(msg)
-                except ValueError:
-                    msg = "Please enter a valid level or chart constant."
-                    raise commands.BadArgument(msg) from None
+                stmt = stmt.limit(count)
+                levels = await LevelRangeConverter().convert(ctx, level)
+
+                if isinstance(levels, LevelRange):
+                    min_level, max_level = levels
+
+                    if min_level is not None:
+                        stmt = stmt.where(
+                            Chart.const >= (min_level.const or min_level.inferred_const)
+                        )
+
+                    if max_level is not None:
+                        stmt = stmt.where(
+                            Chart.const
+                            <= (max_level.const or max_level.inferred_max_const)
+                        )
+                elif levels.const is not None:
+                    stmt = stmt.where(Chart.const == levels.const)
+                else:
+                    stmt = stmt.where(Chart.level == levels.level)
 
                 charts = (await session.execute(stmt)).scalars().all()
 

--- a/chuni_penguin/converters.py
+++ b/chuni_penguin/converters.py
@@ -1,4 +1,5 @@
 import contextlib
+from dataclasses import dataclass
 from typing import NamedTuple, override
 
 from discord import Interaction, Member, User, app_commands
@@ -72,9 +73,32 @@ class RankConverter(commands.Converter[Rank]):
             raise commands.BadArgument(msg) from e
 
 
-class Level(NamedTuple):
+@dataclass
+class Level:
     level: str
     const: float | None
+
+    @property
+    def inferred_const(self):
+        return self.const or float(self.level.replace("+", ".5", 1))
+
+    @property
+    def inferred_max_const(self):
+        if self.const is not None:
+            return self.const
+
+        if self.level.endswith("+"):
+            return float(self.level.replace("+", ".9", 1))
+
+        return (int(self.level) * 10 + 4) / 10
+
+    def __str__(self):
+        return str(self.const) if self.const is not None else self.level
+
+
+class LevelRange(NamedTuple):
+    min_level: Level | None
+    max_level: Level | None
 
 
 class LevelConverter(commands.Converter[Level]):
@@ -122,6 +146,37 @@ class LevelConverter(commands.Converter[Level]):
 
         msg = f'Could not infer level or chart constant from "{escape_markdown(argument)}".'
         raise commands.BadArgument(msg)
+
+
+class LevelRangeConverter(commands.Converter[Level | LevelRange]):
+    @override
+    async def convert(self, ctx: commands.Context, argument: str) -> Level | LevelRange:
+        min_level_str, separator, max_level_str = argument.partition("-")
+        level_converter = LevelConverter()
+
+        if len(max_level_str) <= 0 and len(separator) <= 0:
+            return await level_converter.convert(ctx, min_level_str)
+
+        min_level = (
+            await level_converter.convert(ctx, min_level_str)
+            if len(min_level_str) > 0
+            else None
+        )
+        max_level = (
+            await level_converter.convert(ctx, max_level_str)
+            if len(max_level_str) > 0
+            else None
+        )
+
+        if (
+            min_level is not None
+            and max_level is not None
+            and min_level.inferred_const > max_level.inferred_const
+        ):
+            msg = f"Invalid range: minimum level {min_level} is larger than maximum level {max_level}"
+            raise commands.BadArgument(msg)
+
+        return LevelRange(min_level, max_level)
 
 
 # TODO: Consider inheriting from commands.clean_content instead so we

--- a/chuni_penguin/ui/songlist.py
+++ b/chuni_penguin/ui/songlist.py
@@ -30,7 +30,7 @@ class SonglistPageSource(ListPageSource[Chart]):
                 if chart.sdvxin_chart_view is not None
                 else yt_search_link(chart.song.title, chart.difficulty, chart.level)
             )
-            songlist += f"{idx + start + 1}. {escape_markdown(chart.song.title)} [[{Difficulty(chart.difficulty)} {chart.const}]]({url})\n"
+            songlist += f"{idx + start + 1}. {escape_markdown(chart.song.title)} [[{Difficulty(chart.difficulty)} {chart.const or chart.level}]]({url})\n"
 
         return {
             "embed": discord.Embed(


### PR DESCRIPTION
Ranges are specified using `[LEVEL]-[LEVEL]` format, and are inclusive. Both the minimum level and maximum level can be omitted to create an unbounded range:

- `-14.5`: All charts with constant <= 14.5
- `14.5-`: All charts with constant >= 14.5
- `-`: Literally everything