### PR TITLE
feat(guess): level filters and seeded runs

### DIFF
--- a/chuni_penguin/cogs/gaming/_session.py
+++ b/chuni_penguin/cogs/gaming/_session.py
@@ -1,19 +1,22 @@
 import asyncio
 import io
+import operator
 import random
 import traceback
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from datetime import datetime
 from enum import Enum
+from functools import reduce
 from typing import TYPE_CHECKING, Any, cast
 
 import discord
 import rapidfuzz
+import sqlalchemy
 from discord.ext import songbird
 from discord.ext.commands import Context
 from PIL import Image, ImageDraw, ImageOps
 from rapidfuzz import fuzz
-from sqlalchemy import select, text
+from sqlalchemy import ColumnElement, select
 from sqlalchemy.dialects.sqlite import insert
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.sql import update
@@ -21,7 +24,8 @@ from sqlalchemy.sql import update
 from chuni_penguin.cogs.botutils import CachedAlias
 from chuni_penguin.cogs.events import EventsCog
 from chuni_penguin.constants import ASSETS_DIR
-from chuni_penguin.database import Alias, GuessScore, Song
+from chuni_penguin.converters import Level, LevelRange
+from chuni_penguin.database import Alias, Chart, GuessScore, Song
 from chuni_penguin.logging import logger
 from chuni_penguin.networks.types import Difficulty, Genre
 from chuni_penguin.oggopus import crop_audio, get_audio_duration
@@ -68,7 +72,9 @@ class GuessingGameSession:
         wrong_answers_limit: int | None = None,
         hardcore_mode: bool = False,
         genres: list[Genre] | None = None,
+        levels: list[Level | LevelRange] | None = None,
         volume: int = 15,
+        seed: str | None = None,
     ) -> None:
         self.ctx: Context = ctx
 
@@ -97,6 +103,7 @@ class GuessingGameSession:
         self._hardcore_mode_ignores: set[int] = set()
 
         self.genres: list[Genre] | None = genres
+        self.levels: list[Level | LevelRange] | None = levels
 
         # If stopped by the bot itself, it means that we're restarting.
         self.stopped_by: discord.User | discord.Member | discord.ClientUser | None = (
@@ -106,6 +113,17 @@ class GuessingGameSession:
         self.last_question_was_answered: bool = False
 
         self.volume: int = volume
+
+        self.seeded: bool = seed is not None
+        self.seed: str = (
+            seed
+            if seed is not None
+            else "".join(
+                random.choice("ABCDEFGHIJKLMNPQRSTUVWXYZ123456789") for _ in range(8)
+            )
+        )
+        self.random: random.Random = random.Random(self.seed)
+        self._song_ids: Sequence[int] = []
 
         self._tasks: set[asyncio.Task] = set()
         self._lock: asyncio.Lock = asyncio.Lock()
@@ -136,10 +154,53 @@ class GuessingGameSession:
     def voice_client(self):
         return cast(songbird.SongbirdClient | None, self.ctx.voice_client)
 
+    @property
+    def counts_towards_leaderboard(self):
+        return self.genres is None and self.levels is None and not self.seeded
+
     async def run(
         self,
         after: Callable[[Exception | None], Awaitable[Any]] | None = None,
     ):
+        condition = (Song.genre != "WORLD'S END") & (Song.removed == False)  # noqa: E712
+
+        if self.genres is not None:
+            condition &= Song.chunithm_catcode.in_([g.value for g in self.genres])
+
+        if self.levels is not None:
+            level_conditions: list[ColumnElement[bool]] = []
+
+            for level in self.levels:
+                if isinstance(level, LevelRange):
+                    min_level, max_level = level
+                    lower_range_cond = sqlalchemy.true()
+                    upper_range_cond = sqlalchemy.true()
+
+                    if min_level is not None:
+                        lower_range_cond = Chart.const >= (
+                            min_level.const or min_level.inferred_const
+                        )
+                    if max_level is not None:
+                        upper_range_cond = Chart.const <= (
+                            max_level.const or max_level.inferred_const
+                        )
+
+                    level_conditions.append(lower_range_cond & upper_range_cond)
+                elif level.const is not None:
+                    level_conditions.append(Chart.const == level.const)
+                else:
+                    level_conditions.append(Chart.level == level.level)
+
+            condition &= reduce(operator.or_, level_conditions)
+
+        async with self.bot.begin_db_session() as session:
+            stmt = select(Song.id).where(condition)
+
+            if self.levels is not None:
+                stmt = stmt.join(Chart, Song.id == Chart.song_id).group_by(Song.id)
+
+            self._song_ids = (await session.execute(stmt)).scalars().unique().all()
+
         state = self._current_state
 
         while state is not None:
@@ -237,15 +298,9 @@ class GuessingGameSession:
         else:
             alias_guild_ids = [-1]
 
-        condition = (Song.genre != "WORLD'S END") & (Song.removed == False)  # noqa: E712
-
-        if self.genres is not None:
-            condition &= Song.chunithm_catcode.in_([g.value for g in self.genres])
+        song_id = self.random.choice(self._song_ids)
 
         async with self.bot.begin_db_session() as session:
-            stmt = select(Song.id).where(condition).order_by(text("RANDOM()")).limit(1)
-            song_id = (await session.execute(stmt)).scalar_one()
-
             stmt = (
                 select(Song)
                 .where(Song.id == song_id)
@@ -306,8 +361,8 @@ class GuessingGameSession:
         crop_width, crop_height = self.get_crop_dimensions()
 
         with Image.open(jacket_path) as img:
-            x = random.randrange(0, img.width - crop_width)
-            y = random.randrange(0, img.height - crop_height)
+            x = self.random.randrange(0, img.width - crop_width)
+            y = self.random.randrange(0, img.height - crop_height)
 
             img = img.crop((x, y, x + crop_width, y + crop_height))
 
@@ -316,11 +371,11 @@ class GuessingGameSession:
                 Difficulty.master,
                 Difficulty.ultima,
             }:
-                rotation = random.randrange(0, 4)
+                rotation = self.random.randrange(0, 4)
                 img = img.rotate(90 * rotation)
 
             if self.difficulty == Difficulty.ultima:
-                should_invert = random.random() < 0.5
+                should_invert = self.random.random() < 0.5
 
                 if should_invert:
                     img = ImageOps.invert(img.convert("RGB"))
@@ -387,7 +442,8 @@ class GuessingGameSession:
         # Usually, the first measure of game audio will be silent. Silent audio sucks, especially
         # on games where the audio is shorter, so we guard against the most basic of them first.
         audio_start = max(
-            random.randrange(0, audio_duration - audio_length), 60 / (song.bpm / 4)
+            self.random.randrange(0, audio_duration - audio_length),
+            60 / (song.bpm / 4),
         )
 
         return (
@@ -446,7 +502,7 @@ class GuessingGameSession:
         return f"{self.wrong_answers_limit - self.wrong_answers}/{self.wrong_answers_limit}"
 
     async def increment_score(self, user_id: int):
-        if self.genres is not None:
+        if not self.counts_towards_leaderboard:
             return
 
         guild_id = self.ctx.guild.id if self.ctx.guild else -1

--- a/chuni_penguin/cogs/gaming/cog.py
+++ b/chuni_penguin/cogs/gaming/cog.py
@@ -10,7 +10,13 @@ from discord.utils import MISSING
 from sqlalchemy import delete
 
 from chuni_penguin.context import PenguinGuildContext
-from chuni_penguin.converters import DifficultyConverter, GenreConverter
+from chuni_penguin.converters import (
+    DifficultyConverter,
+    GenreConverter,
+    Level,
+    LevelRange,
+    LevelRangeConverter,
+)
 from chuni_penguin.database.models import GuessScore
 from chuni_penguin.flags import DiscordArguments
 from chuni_penguin.logging import logged_prefix_command
@@ -33,6 +39,8 @@ class GuessArguments:
     hardcore: bool
     genres: list[Genre] | None
     volume: int
+    levels: list[Level | LevelRange] | None
+    seed: str | None
 
 
 class GamingCog(commands.Cog, name="Games"):
@@ -64,6 +72,13 @@ class GamingCog(commands.Cog, name="Games"):
         parser.add_argument("-h", "--hardcore", action="store_true")
         parser.add_argument("-g", "--genre", type=str, nargs="*")
         parser.add_argument("-v", "--volume", type=int, required=False, default=15)
+        parser.add_argument(
+            "-l",
+            "--levels",
+            type=lambda s: LevelRangeConverter().convert(ctx, s),
+            nargs="*",
+        )
+        parser.add_argument("--seed", type=str, required=False, default=None)
 
         try:
             args, _ = await parser.parse_known_intermixed_args(shlex_split(arguments))
@@ -77,10 +92,23 @@ class GamingCog(commands.Cog, name="Games"):
         wrong: int | None = args.wrong
         hardcore: bool = args.hardcore
         genre: list[str] | None = args.genre
+        levels: list[Level | LevelRange] | None = args.levels
         volume: int = args.volume
+        seed: str | None = args.seed
 
         if genre is not None and len(genre) == 0:
             msg = "No genres were specified."
+            raise commands.BadArgument(msg)
+
+        if levels is not None and len(levels) == 0:
+            msg = "No levels were specified."
+            raise commands.BadArgument(msg)
+
+        if seed is not None and (
+            len(seed) != 8
+            or any(c not in "ABCDEFGHIJKLMNPQRSTUVWXYZ123456789" for c in seed)
+        ):
+            msg = "Invalid seed. Must contain exactly 8 uppercase characters (except `O`) and digits (except `0`)."
             raise commands.BadArgument(msg)
 
         if volume < 0 or volume > 100:
@@ -98,11 +126,13 @@ class GamingCog(commands.Cog, name="Games"):
             if genre is not None
             else None,
             volume,
+            levels,
+            seed,
         )
 
     @commands.group(
         "guess",
-        usage="<game_type> [-h] [-d <difficulty>] [-q <questions>] [-s <score>] [-t <time>] [-w <wrong>] [-g <genres...>]",
+        usage="<game_type> [-h] [-d <difficulty>] [-q <questions>] [-s <score>] [-t <time>] [-w <wrong>] [-g <genres...>] [-l <levels...>] [--seed <seed>]",
         invoke_without_command=True,
     )
     @logged_prefix_command
@@ -113,7 +143,7 @@ class GamingCog(commands.Cog, name="Games"):
 
     @guess.command(
         "jacket",
-        usage="[-h] [-d <difficulty>] [-q <questions>] [-s <score>] [-t <time>] [-w <wrong>] [-g <genres...>]",
+        usage="[-h] [-d <difficulty>] [-q <questions>] [-s <score>] [-t <time>] [-w <wrong>] [-g <genres...>] [-l <levels...>] [--seed <seed>]",
     )
     @commands.bot_has_permissions(
         add_reactions=True,
@@ -137,13 +167,15 @@ class GamingCog(commands.Cog, name="Games"):
         `-w`, `--wrong`: The number of questions to get wrong before the game is stopped. Default is unlimited.
         `-h`, `--hardcore`: Hardcore mode, each player gets one chance to answer each question correctly.
         `-g`, `--genre`: Limit song pool to the provided genre. Can specify multiple genres, e.g. `-g original niconico`. **Games played with this option will not be counted towards the leaderboard!**
+        `-l`, `--level`: Limit song pool to the provided chart levels. Can specify a level (13+), a chart constant (13.8), or a range (13.5-13.8). Can specify multiple levels, e.g. `-g 13+ 15`. **Games played with this option will not be counted towards the leaderboard!**
+        `--seed`: Specify a seed for the game. A seed contains 8 uppercase characters and digits (except `O` and `0`). A seed only gives the same game if all other options are the same. A seed does not guarantee the same game as new songs get added. **Games played with this option will not be counted towards the leaderboard!**
         """
 
         await self._guess_without_voice_channel(ctx, GuessingGameType.IMAGE, arguments)
 
     @guess.command(
         "audio",
-        usage="[-h] [-d <difficulty>] [-q <questions>] [-s <score>] [-t <time>] [-w <wrong>] [-g <genres...>]",
+        usage="[-h] [-d <difficulty>] [-q <questions>] [-s <score>] [-t <time>] [-w <wrong>] [-g <genres...>] [-l <levels...>] [--seed <seed>]",
     )
     @commands.bot_has_permissions(
         add_reactions=True,
@@ -167,6 +199,8 @@ class GamingCog(commands.Cog, name="Games"):
         `-w`, `--wrong`: The number of questions to get wrong before the game is stopped. Default is unlimited.
         `-h`, `--hardcore`: Hardcore mode, each player gets one chance to answer each question correctly.
         `-g`, `--genre`: Limit song pool to the provided genre. Can specify multiple genres, e.g. `-g original niconico`. **Games played with this option will not be counted towards the leaderboard!**
+        `-l`, `--level`: Limit song pool to the provided chart levels. Can specify a level (13+), a chart constant (13.8), or a range (13.5-13.8). Can specify multiple levels, e.g. `-g 13+ 15`. **Games played with this option will not be counted towards the leaderboard!**
+        `--seed`: Specify a seed for the game. A seed contains 8 uppercase characters and digits (except `O` and `0`). A seed only gives the same game if all other options are the same. A seed does not guarantee the same game as new songs get added. **Games played with this option will not be counted towards the leaderboard!**
         """
 
         await self._guess_without_voice_channel(
@@ -175,7 +209,7 @@ class GamingCog(commands.Cog, name="Games"):
 
     @guess.command(
         "voice",
-        usage="[-h] [-d <difficulty>] [-q <questions>] [-s <score>] [-t <time>] [-w <wrong>] [-v <volume>] [-g <genres...>]",
+        usage="[-h] [-d <difficulty>] [-q <questions>] [-s <score>] [-t <time>] [-w <wrong>] [-v <volume>] [-g <genres...>] [-l <levels...>] [--seed <seed>]",
     )
     @commands.guild_only()
     @commands.bot_has_permissions(
@@ -200,7 +234,9 @@ class GamingCog(commands.Cog, name="Games"):
         `-w`, `--wrong`: The number of questions to get wrong before the game is stopped. Default is unlimited.
         `-h`, `--hardcore`: Hardcore mode, each player gets one chance to answer each question correctly.
         `-g`, `--genre`: Limit song pool to the provided genre. Can specify multiple genres, e.g. `-g original niconico`. **Games played with this option will not be counted towards the leaderboard!**
+        `-l`, `--level`: Limit song pool to the provided chart levels. Can specify a level (13+), a chart constant (13.8), or a range (13.5-13.8). Can specify multiple levels, e.g. `-g 13+ 15`. **Games played with this option will not be counted towards the leaderboard!**
         `-v`, `--volume`: The starting volume of the audio. Defaults to 15% (can be very loud!)
+        `--seed`: Specify a seed for the game. A seed contains 8 uppercase characters and digits (except `O` and `0`). A seed only gives the same game if all other options are the same. A seed does not guarantee the same game as new songs get added. **Games played with this option will not be counted towards the leaderboard!**
         """
 
         if self.shutting_down:
@@ -270,6 +306,8 @@ class GamingCog(commands.Cog, name="Games"):
                 hardcore_mode=args.hardcore,
                 genres=args.genres,
                 volume=args.volume,
+                levels=args.levels,
+                seed=args.seed,
             )
 
         if session.time_per_question is MISSING:
@@ -411,7 +449,7 @@ class GamingCog(commands.Cog, name="Games"):
     async def guess_reset(self, ctx: PenguinGuildContext):
         """Resets the guess leaderboard for this server.
 
-        The user calling this command must have the Manage Server permission.
+        The user invoking this command must have the Manage Server permission.
         """
 
         async with self.bot.begin_db_session() as session:

--- a/chuni_penguin/cogs/gaming/states/end_game.py
+++ b/chuni_penguin/cogs/gaming/states/end_game.py
@@ -1,4 +1,3 @@
-import random
 from typing import TYPE_CHECKING, override
 
 import discord
@@ -76,6 +75,13 @@ async def end_game(
             name="Genres", value=", ".join([str(g) for g in session.genres])
         )
 
+    if session.levels is not None:
+        embed.add_field(
+            name="Levels", value=", ".join([str(level) for level in session.levels])
+        )
+
+    embed.add_field(name="Seed", value=session.seed)
+
     embed.add_field(name="Final Scores", value=session.print_score_list(), inline=False)
 
     if footer is not None:
@@ -98,7 +104,7 @@ async def end_game(
                 ]
             )
 
-        embed.set_footer(text=random.choice(tips))
+        embed.set_footer(text=session.random.choice(tips))
 
     retry_btn = RetryGameButton(
         mode=session.game_type,
@@ -109,13 +115,32 @@ async def end_game(
         wrong=session.wrong_answers_limit,
         hardcore=session.hardcore_mode,
         genres=session.genres,
+        levels=session.levels,
         volume=session.volume,
     )
+    retry_seeded_btn = RetryGameButton(
+        mode=session.game_type,
+        difficulty=session.difficulty,
+        questions=session.question_count or 20,
+        score=session.score_limit,
+        time=session.time_per_question,
+        wrong=session.wrong_answers_limit,
+        hardcore=session.hardcore_mode,
+        genres=session.genres,
+        levels=session.levels,
+        volume=session.volume,
+        seed=session.seed,
+    )
+
+    view = discord.ui.View(timeout=None)
 
     if len(retry_btn.custom_id) <= 100:
-        view = discord.ui.View(timeout=None)
         view.add_item(retry_btn)
-    else:
+
+    if len(retry_seeded_btn.custom_id) <= 100:
+        view.add_item(retry_seeded_btn)
+
+    if view.total_children_count == 0:
         view = MISSING
 
     await session.channel.send(embed=embed, view=view)

--- a/chuni_penguin/cogs/gaming/states/start.py
+++ b/chuni_penguin/cogs/gaming/states/start.py
@@ -19,6 +19,10 @@ class StartState(GuessingGameState):
             color=discord.Color.yellow(),
             title="A new game is starting in 5 seconds!",
         )
+
+        if not self.session.counts_towards_leaderboard:
+            embed.description = "**This game will not count towards the leaderboard!**"
+
         embed.add_field(
             name="Started by", value=self.session.ctx.author.mention, inline=True
         )
@@ -56,10 +60,18 @@ class StartState(GuessingGameState):
             embed.add_field(name="Hardcore mode", value="Enabled", inline=True)
 
         if self.session.genres is not None:
-            embed.description = "**This game will not count towards the leaderboard!**"
             embed.add_field(
                 name="Genres", value=", ".join([str(g) for g in self.session.genres])
             )
+
+        if self.session.levels is not None:
+            embed.add_field(
+                name="Levels",
+                value=", ".join([str(level) for level in self.session.levels]),
+            )
+
+        if self.session.seeded:
+            embed.add_field(name="Seed", value=self.session.seed)
 
         await self.session.ctx.send(embed=embed)
         return WaitState(self.session, 5, self.session.question_state_cls(self.session))

--- a/chuni_penguin/converters.py
+++ b/chuni_penguin/converters.py
@@ -100,6 +100,16 @@ class LevelRange(NamedTuple):
     min_level: Level | None
     max_level: Level | None
 
+    def __str__(self) -> str:
+        if self.min_level is not None and self.max_level is not None:
+            return f"{self.min_level}-{self.max_level}"
+        if self.min_level is not None:
+            return f"{self.min_level}-"
+        if self.max_level is not None:
+            return f"-{self.max_level}"
+
+        return "-"
+
 
 class LevelConverter(commands.Converter[Level]):
     @override

--- a/chuni_penguin/ui/gaming.py
+++ b/chuni_penguin/ui/gaming.py
@@ -10,6 +10,7 @@ from sqlalchemy import Row, desc, func, select
 from chuni_penguin.cogs.gaming._session import GuessingGameSession, GuessingGameType
 from chuni_penguin.config import config
 from chuni_penguin.context import PenguinGuildContext
+from chuni_penguin.converters import Level, LevelRange, LevelRangeConverter
 from chuni_penguin.database import GuessScore
 from chuni_penguin.networks.types import Difficulty, Genre
 
@@ -177,7 +178,7 @@ class GuessLeaderboardView(PaginationView):
 
 class RetryGameButton(
     discord.ui.DynamicItem[discord.ui.Button],
-    template=r"retryguess(?P<mode>[012]):(?P<difficulty>\d+):(?P<questions>\d+):(?P<score>\d*):(?P<time>\d+):(?P<wrong>\d*):(?P<hardcore>[01]):(?P<genres>[\d,]*)(?::(?P<volume>\d+))?",
+    template=r"retryguess(?P<mode>[012]):(?P<difficulty>\d+):(?P<questions>\d+):(?P<score>\d*):(?P<time>\d+):(?P<wrong>\d*):(?P<hardcore>[01]):(?P<genres>[\d,]*)(?::(?P<volume>\d+))?(?::(?P<levels>[\d\-+.,]*))?(?::(?P<seed>[A-NP-Z1-9]{8})?)?",
 ):
     def __init__(
         self,
@@ -190,7 +191,9 @@ class RetryGameButton(
         wrong: int | None,
         hardcore: bool,
         genres: list[Genre] | None,
+        levels: list[Level | LevelRange] | None,
         volume: int,
+        seed: str | None = None,
         row: int | None = None,
     ) -> None:
         if mode == GuessingGameType.IMAGE:
@@ -203,11 +206,29 @@ class RetryGameButton(
             msg = f"Unknown guess game mode: {mode}"
             raise ValueError(msg)
 
+        custom_id_parts: list[str] = [
+            mode_id,
+            str(difficulty.value),
+            str(questions),
+            str(score) if score is not None else "",
+            str(time),
+            str(wrong) if wrong is not None else "",
+            "1" if hardcore else "0",
+            ",".join([str(g.value) for g in genres]) if genres else "",
+            str(volume),
+            ",".join([str(level) for level in levels]) if levels else "",
+            seed if seed is not None else "",
+        ]
+
         super().__init__(
             discord.ui.Button(
-                style=discord.ButtonStyle.green,
-                label="Retry",
-                custom_id=f"retryguess{mode_id}:{difficulty.value}:{questions}:{score if score is not None else ''}:{time}:{wrong if wrong is not None else ''}:{'1' if hardcore else '0'}:{','.join([str(g.value) for g in genres]) if genres else ''}:{volume}",
+                style=(
+                    discord.ButtonStyle.green
+                    if seed is None
+                    else discord.ButtonStyle.secondary
+                ),
+                label="Retry" if seed is None else "Retry (same seed)",
+                custom_id=f"retryguess{':'.join(custom_id_parts)}",
             ),
             row=row,
         )
@@ -221,6 +242,8 @@ class RetryGameButton(
         self.hardcore = hardcore
         self.genres = genres
         self.volume = volume
+        self.levels = levels
+        self.seed = seed
 
     @classmethod
     async def from_custom_id(  # pyright: ignore[reportIncompatibleMethodOverride]
@@ -253,6 +276,21 @@ class RetryGameButton(
         )
         volume = int(match["volume"]) if match["volume"] else 15
 
+        level_range_converter = LevelRangeConverter()
+        levels = (
+            await asyncio.gather(
+                *[
+                    # This doesn't actually need a context object, that's just how the
+                    # converter interface goes.
+                    level_range_converter.convert(None, level)  # pyright: ignore[reportArgumentType]
+                    for level in match["levels"].split(",")
+                ]
+            )
+            if match["levels"]
+            else None
+        )
+        seed = match["seed"]
+
         return cls(
             mode=mode,
             difficulty=difficulty,
@@ -263,6 +301,8 @@ class RetryGameButton(
             hardcore=hardcore,
             genres=genres,
             volume=volume,
+            levels=levels,
+            seed=seed,
         )
 
     @override
@@ -351,6 +391,8 @@ class RetryGameButton(
                 hardcore_mode=self.hardcore,
                 genres=self.genres,
                 volume=self.volume,
+                levels=self.levels,
+                seed=self.seed,
             )
 
         voice_channel_id = (


### PR DESCRIPTION
- Supports filtering by chart levels using the `-l, --levels` option. Specification similar to `c>random` and `c>find`.
- Since we load the list of songs ahead of time anyways, switch everything to a single random instance and enable seeded runs.

Closes #97