### PR TITLE
fix(db): uint64 for Discord identifiers

### DIFF
--- a/chuni_penguin/cogs/autocompleters.py
+++ b/chuni_penguin/cogs/autocompleters.py
@@ -24,7 +24,7 @@ class AutocompletersCog(commands.Cog, name="Autocompleters"):
         if len(current) < 3:
             return []
 
-        aliases = self.utils.alias_cache[-1].copy()
+        aliases = self.utils.alias_cache[0].copy()
 
         if (guild_id := interaction.guild_id) is not None and (
             guild_aliases := self.utils.alias_cache.get(guild_id)

--- a/chuni_penguin/cogs/botutils.py
+++ b/chuni_penguin/cogs/botutils.py
@@ -91,7 +91,7 @@ class UtilsCog(commands.Cog, name="Utils"):
         self.alias_cache.clear()
 
         titles = set()
-        global_aliases = self.alias_cache.setdefault(-1, [])
+        global_aliases = self.alias_cache.setdefault(0, [])
 
         for song in songs:
             title_lower = song.title.lower()
@@ -100,7 +100,7 @@ class UtilsCog(commands.Cog, name="Utils"):
                 titles.add(title_lower)
 
                 global_aliases.append(
-                    CachedAlias(None, title_lower, song.title, song.id, -1)
+                    CachedAlias(None, title_lower, song.title, song.id, 0)
                 )
 
             for alias in song.aliases:
@@ -123,7 +123,7 @@ class UtilsCog(commands.Cog, name="Utils"):
                 titles.add(artist_lower)
 
                 global_aliases.append(
-                    CachedAlias(None, artist_lower, song.title, song.id, -1)
+                    CachedAlias(None, artist_lower, song.title, song.id, 0)
                 )
 
     async def guild_prefix(self, ctx: Context) -> str:
@@ -354,7 +354,7 @@ class UtilsCog(commands.Cog, name="Utils"):
         tuple[Song, Alias | None, float]
             The third item is the similarity of the matched song.
         """
-        aliases = self.alias_cache[-1][:]
+        aliases = self.alias_cache[0][:]
 
         if (
             guild_id is not None
@@ -404,7 +404,7 @@ class UtilsCog(commands.Cog, name="Utils"):
         load_charts: bool = False,
         load_global_aliases: bool = False,
     ) -> SongSearchResult:
-        aliases = self.alias_cache[-1][:]
+        aliases = self.alias_cache[0][:]
 
         if (
             guild_id is not None
@@ -433,7 +433,7 @@ class UtilsCog(commands.Cog, name="Utils"):
 
             if load_global_aliases:
                 stmt = stmt.outerjoin(
-                    Alias, (Alias.song_id == Song.id) & (Alias.guild_id == -1)
+                    Alias, (Alias.song_id == Song.id) & (Alias.guild_id == 0)
                 ).options(contains_eager(Song.aliases))
 
             songs = (await session.execute(stmt)).scalars().unique()

--- a/chuni_penguin/cogs/chunithm/search.py
+++ b/chuni_penguin/cogs/chunithm/search.py
@@ -172,7 +172,7 @@ class SearchCog(commands.Cog, name="Search"):
         added_alias_lower = added_alias.lower()
 
         if global_alias:
-            guild_id = -1
+            guild_id = 0
         elif ctx.guild is not None:
             guild_id = ctx.guild.id
         else:
@@ -205,7 +205,7 @@ class SearchCog(commands.Cog, name="Search"):
 
                 if not global_alias:
                     condition = condition & (
-                        (Alias.guild_id == -1) | (Alias.guild_id == guild_id)
+                        (Alias.guild_id == 0) | (Alias.guild_id == guild_id)
                     )
 
                 stmt = select(Alias).where(condition).options(joinedload(Alias.song))
@@ -225,12 +225,12 @@ class SearchCog(commands.Cog, name="Search"):
                 )
                 aliases = (await session.execute(stmt)).scalars().all()
 
-                if len(aliases) > 0 and aliases[0].guild_id == -1:
+                if len(aliases) > 0 and aliases[0].guild_id == 0:
                     msg = f"**{emd(added_alias)}** already exists (global alias for **{emd(aliases[0].song.title)}**)."
                     raise commands.BadArgument(msg)
 
-                if len(aliases) > 0 and aliases[0].guild_id != -1:
-                    aliases[0].guild_id = -1
+                if len(aliases) > 0 and aliases[0].guild_id != 0:
+                    aliases[0].guild_id = 0
                     aliases[0].owner_id = None
                     aliases[0].song_id = song.id
                     await session.merge(aliases[0])
@@ -249,7 +249,7 @@ class SearchCog(commands.Cog, name="Search"):
                     select(Alias)
                     .where(
                         (func.lower(Alias.alias) == added_alias_lower)
-                        & ((Alias.guild_id == -1) | (Alias.guild_id == guild_id))
+                        & ((Alias.guild_id == 0) | (Alias.guild_id == guild_id))
                     )
                     .options(joinedload(Alias.song))
                 )
@@ -258,7 +258,7 @@ class SearchCog(commands.Cog, name="Search"):
                 if alias_unit is not None:
                     msg = (
                         f"**{emd(added_alias)}** already exists "
-                        f"({'global ' if alias_unit.guild_id == -1 else ''}alias for **{emd(alias_unit.song.title)}**)."
+                        f"({'global ' if alias_unit.guild_id == 0 else ''}alias for **{emd(alias_unit.song.title)}**)."
                     )
                     raise commands.BadArgument(msg)
 
@@ -324,7 +324,7 @@ class SearchCog(commands.Cog, name="Search"):
             condition = func.lower(Alias.alias) == removed_alias.lower()
 
             if is_alias_manager:
-                guild_condition = Alias.guild_id == -1
+                guild_condition = Alias.guild_id == 0
 
                 if ctx.guild is not None:
                     guild_condition |= Alias.guild_id == ctx.guild.id
@@ -338,7 +338,7 @@ class SearchCog(commands.Cog, name="Search"):
 
             stmt = select(Alias).where(condition)
 
-            # when searching for guild_id = ctx.guild.id or guild_id = -1, the cases that happen are
+            # when searching for guild_id = ctx.guild.id or guild_id = 0, the cases that happen are
             # - it is a global alias, in which case there is only *the* global alias
             # - it is a guild alias, in which case the global alias doesn't exist
             # therefore there should be only one or no aliases
@@ -361,7 +361,7 @@ class SearchCog(commands.Cog, name="Search"):
 
         await self.utils._reload_alias_cache()
         await ctx.reply(
-            f"Removed {'global ' if alias.guild_id == -1 else ''}alias **{emd(removed_alias)}**.",
+            f"Removed {'global ' if alias.guild_id == 0 else ''}alias **{emd(removed_alias)}**.",
             mention_author=False,
         )
 
@@ -395,12 +395,12 @@ class SearchCog(commands.Cog, name="Search"):
             color=discord.Color.yellow(),
         )
         embed.description = ""
-        global_aliases = [x.alias for x in aliases if x.guild_id == -1]
+        global_aliases = [x.alias for x in aliases if x.guild_id == 0]
 
         if len(global_aliases) > 0:
             embed.description += (
                 "**Global aliases:**\n"
-                f"{', '.join([x.alias for x in aliases if x.guild_id == -1])}"
+                f"{', '.join([x.alias for x in aliases if x.guild_id == 0])}"
             )
 
         if ctx.guild is not None:

--- a/chuni_penguin/cogs/gaming/_session.py
+++ b/chuni_penguin/cogs/gaming/_session.py
@@ -293,10 +293,7 @@ class GuessingGameSession:
         return 1
 
     async def _get_random_song(self):
-        if self.ctx.guild is not None:
-            alias_guild_ids = [-1, self.ctx.guild.id]
-        else:
-            alias_guild_ids = [-1]
+        alias_guild_ids = [0, self.ctx.guild.id] if self.ctx.guild is not None else [0]
 
         song_id = self.random.choice(self._song_ids)
 
@@ -505,7 +502,7 @@ class GuessingGameSession:
         if not self.counts_towards_leaderboard:
             return
 
-        guild_id = self.ctx.guild.id if self.ctx.guild else -1
+        guild_id = self.ctx.guild.id if self.ctx.guild else 0
 
         async with self.bot.begin_db_session() as session, session.begin():
             stmt = insert(GuessScore).values(

--- a/chuni_penguin/cogs/web.py
+++ b/chuni_penguin/cogs/web.py
@@ -268,7 +268,7 @@ async def _get_songlist(bot: "ChuniBot"):
             "id": song.id,
             "chunirec_id": song.chunirec_id,
             "title": song.title,
-            "aliases": [x.alias for x in song.aliases if x.guild_id == -1],
+            "aliases": [x.alias for x in song.aliases if x.guild_id == 0],
             "artist": song.artist,
             "genre": song.genre,
             "release_date": song.release,

--- a/chuni_penguin/database/alembic/versions/2026_01_13_0853-304e2e43729c_fix_1_in_uint64.py
+++ b/chuni_penguin/database/alembic/versions/2026_01_13_0853-304e2e43729c_fix_1_in_uint64.py
@@ -1,0 +1,25 @@
+"""fix -1 in uint64
+
+Revision ID: 304e2e43729c
+Revises: 6d34ec73965f
+Create Date: 2026-01-13 08:53:55.846533
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "304e2e43729c"
+down_revision: Union[str, None] = "6d34ec73965f"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("UPDATE aliases SET guild_id = 0 WHERE guild_id = -1")
+
+
+def downgrade() -> None:
+    op.execute("UPDATE aliases SET guild_id = -1 WHERE guild_id = 0")

--- a/chuni_penguin/database/alembic/versions/2026_01_13_0853-304e2e43729c_fix_1_in_uint64.py
+++ b/chuni_penguin/database/alembic/versions/2026_01_13_0853-304e2e43729c_fix_1_in_uint64.py
@@ -19,7 +19,9 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     op.execute("UPDATE aliases SET guild_id = 0 WHERE guild_id = -1")
+    op.execute("UPDATE guess_leaderboard SET guild_id = 0 WHERE guild_id = -1")
 
 
 def downgrade() -> None:
     op.execute("UPDATE aliases SET guild_id = -1 WHERE guild_id = 0")
+    op.execute("UPDATE guess_leaderboard SET guild_id = -1 WHERE guild_id = 0")

--- a/chuni_penguin/database/alembic/versions/2026_01_13_0853-304e2e43729c_fix_1_in_uint64.py
+++ b/chuni_penguin/database/alembic/versions/2026_01_13_0853-304e2e43729c_fix_1_in_uint64.py
@@ -8,6 +8,7 @@ Create Date: 2026-01-13 08:53:55.846533
 
 from typing import Sequence, Union
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -18,10 +19,16 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
+    with op.batch_alter_table("guess_leaderboard") as batch_op:
+        batch_op.alter_column("guild_id", server_default=sa.text("0"))
+
     op.execute("UPDATE aliases SET guild_id = 0 WHERE guild_id = -1")
     op.execute("UPDATE guess_leaderboard SET guild_id = 0 WHERE guild_id = -1")
 
 
 def downgrade() -> None:
+    with op.batch_alter_table("guess_leaderboard") as batch_op:
+        batch_op.alter_column("guild_id", server_default=sa.text("-1"))
+
     op.execute("UPDATE aliases SET guild_id = -1 WHERE guild_id = 0")
     op.execute("UPDATE guess_leaderboard SET guild_id = -1 WHERE guild_id = 0")

--- a/chuni_penguin/database/base.py
+++ b/chuni_penguin/database/base.py
@@ -1,8 +1,11 @@
 from datetime import datetime, timezone
 
-from sqlalchemy import DateTime, Dialect, TypeDecorator
+from sqlalchemy import BigInteger, DateTime, Dialect, TypeDecorator
 from sqlalchemy.ext.asyncio import AsyncAttrs
 from sqlalchemy.orm import DeclarativeBase
+
+INT64_MAX = 2**63 - 1
+UINT64_MAX = 2**64 - 1
 
 
 class DateTimeUTC(TypeDecorator[datetime]):
@@ -36,6 +39,44 @@ class DateTimeUTC(TypeDecorator[datetime]):
         if value.tzinfo is None:
             return value.replace(tzinfo=timezone.utc)
         return value
+
+
+class UInt64Integer(TypeDecorator[int]):
+    """
+    A uint64 that's represented as an int64 with the same bit representation
+    in the database.
+    """
+
+    impl = BigInteger()
+    cache_ok = True
+
+    @property
+    def python_type(self) -> type[int]:
+        return int
+
+    def process_bind_param(self, value: int | None, dialect: Dialect) -> int | None:
+        if value is None:
+            return value
+
+        if value < 0 or value > UINT64_MAX:
+            msg = f"uint64 requires 0 <= value <= {UINT64_MAX}, got {value=}"
+            raise ValueError(msg)
+
+        if value <= INT64_MAX:
+            return value
+
+        # Reference: https://graphics.stanford.edu/~seander/bithacks.html#VariableSignExtend
+        value = value & 0xFFFFFFFFFFFFFFFF
+        return (value ^ 0x8000000000000000) - 0x8000000000000000
+
+    def process_result_value(self, value: int | None, dialect: Dialect) -> int | None:
+        if value is None:
+            return value
+
+        if value >= 0:
+            return value
+
+        return value & 0xFFFFFFFFFFFFFFFF
 
 
 class Base(DeclarativeBase, AsyncAttrs):

--- a/chuni_penguin/database/bot.py
+++ b/chuni_penguin/database/bot.py
@@ -1,13 +1,13 @@
 from sqlalchemy import text
 from sqlalchemy.orm import Mapped, mapped_column
 
-from .base import Base
+from .base import Base, UInt64Integer
 
 
 class Denylist(Base):
     __tablename__ = "denylist"
 
-    object_id: Mapped[int] = mapped_column(primary_key=True)
+    object_id: Mapped[int] = mapped_column(UInt64Integer(), primary_key=True)
     reason: Mapped[str | None] = mapped_column(
         default=None, server_default=text("NULL")
     )

--- a/chuni_penguin/database/guilds.py
+++ b/chuni_penguin/database/guilds.py
@@ -1,11 +1,10 @@
-from sqlalchemy import BigInteger
 from sqlalchemy.orm import Mapped, mapped_column
 
-from .base import Base
+from .base import Base, UInt64Integer
 
 
 class Prefix(Base):
     __tablename__ = "guild_prefix"
 
-    guild_id: Mapped[int] = mapped_column(BigInteger(), primary_key=True)
+    guild_id: Mapped[int] = mapped_column(UInt64Integer(), primary_key=True)
     prefix: Mapped[str] = mapped_column(nullable=False)

--- a/chuni_penguin/database/kamaitachi.py
+++ b/chuni_penguin/database/kamaitachi.py
@@ -1,10 +1,10 @@
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import JSON, BigInteger, Index, text
+from sqlalchemy import JSON, Index, text
 from sqlalchemy.orm import Mapped, mapped_column
 
-from .base import Base
+from .base import Base, UInt64Integer
 
 
 class PendingKamaitachiImport(Base):
@@ -12,7 +12,7 @@ class PendingKamaitachiImport(Base):
     __table_args__ = (Index("ix_pending_kamaitachi_imports_discord_id", "discord_id"),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    discord_id: Mapped[int] = mapped_column(BigInteger())
+    discord_id: Mapped[int] = mapped_column(UInt64Integer())
     import_data: Mapped[dict[str, Any]] = mapped_column(JSON())
     created_at: Mapped[datetime] = mapped_column(
         server_default=text("CURRENT_TIMESTAMP"),

--- a/chuni_penguin/database/minigames.py
+++ b/chuni_penguin/database/minigames.py
@@ -1,7 +1,7 @@
-from sqlalchemy import BigInteger, Index, UniqueConstraint, text
+from sqlalchemy import Index, UniqueConstraint, text
 from sqlalchemy.orm import Mapped, mapped_column
 
-from .base import Base
+from .base import Base, UInt64Integer
 
 
 class GuessScore(Base):
@@ -26,9 +26,9 @@ class GuessScore(Base):
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    discord_id: Mapped[int] = mapped_column(BigInteger())
+    discord_id: Mapped[int] = mapped_column(UInt64Integer())
     guild_id: Mapped[int] = mapped_column(
-        BigInteger(), nullable=False, default=-1, server_default=text("-1")
+        UInt64Integer(), nullable=False, default=0, server_default=text("0")
     )
     difficulty: Mapped[int] = mapped_column(
         nullable=False, default=-1, server_default=text("-1")

--- a/chuni_penguin/database/pbs.py
+++ b/chuni_penguin/database/pbs.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 
 from sqlalchemy import (
-    BigInteger,
     ForeignKey,
     ForeignKeyConstraint,
     Index,
@@ -15,13 +14,13 @@ from sqlalchemy.orm import (
 
 from chuni_penguin.networks.types import ClearLamp, ComboLamp
 
-from .base import Base
+from .base import Base, UInt64Integer
 
 
 class PersonalBest(Base):
     __tablename__ = "personal_bests"
 
-    discord_id: Mapped[int] = mapped_column(BigInteger())
+    discord_id: Mapped[int] = mapped_column(UInt64Integer())
     network: Mapped[str] = mapped_column()
     song_id: Mapped[int] = mapped_column(
         ForeignKey("chunirec_songs.id", onupdate="CASCADE", ondelete="CASCADE"),

--- a/chuni_penguin/database/songs.py
+++ b/chuni_penguin/database/songs.py
@@ -3,7 +3,6 @@ from typing import Optional
 from discord.ext import commands
 from discord.utils import escape_markdown
 from sqlalchemy import (
-    BigInteger,
     ForeignKey,
     ForeignKeyConstraint,
     Index,
@@ -18,7 +17,7 @@ from sqlalchemy.orm import (
 
 from chuni_penguin.utils import sdvxin_link
 
-from .base import Base
+from .base import Base, UInt64Integer
 
 
 class Song(Base):
@@ -166,12 +165,12 @@ class Alias(Base):
     rowid: Mapped[int] = mapped_column(primary_key=True)
 
     alias: Mapped[str] = mapped_column(nullable=False)
-    guild_id: Mapped[int] = mapped_column(BigInteger(), nullable=False)
+    guild_id: Mapped[int] = mapped_column(UInt64Integer(), nullable=False)
     song_id: Mapped[int] = mapped_column(
         ForeignKey("chunirec_songs.id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
     )
-    owner_id: Mapped[Optional[int]] = mapped_column(BigInteger(), nullable=True)
+    owner_id: Mapped[Optional[int]] = mapped_column(UInt64Integer(), nullable=True)
     uses: Mapped[int] = mapped_column(
         nullable=False, default=0, server_default=text("0")
     )

--- a/chuni_penguin/database/users.py
+++ b/chuni_penguin/database/users.py
@@ -1,15 +1,15 @@
 from datetime import datetime
 
-from sqlalchemy import BigInteger, Boolean, Index, PrimaryKeyConstraint, String, text
+from sqlalchemy import Boolean, Index, PrimaryKeyConstraint, String, text
 from sqlalchemy.orm import Mapped, mapped_column
 
-from .base import Base
+from .base import Base, UInt64Integer
 
 
 class Cookie(Base):
     __tablename__ = "cookies"
 
-    discord_id: Mapped[int] = mapped_column(BigInteger(), primary_key=True)
+    discord_id: Mapped[int] = mapped_column(UInt64Integer(), primary_key=True)
     cookie: Mapped[str] = mapped_column(String(64), nullable=False)
     kamaitachi_token: Mapped[str | None] = mapped_column(String(40), nullable=True)
     is_contributor: Mapped[bool] = mapped_column(
@@ -25,7 +25,7 @@ class UserConfig(Base):
     __table_args__ = (Index("ix_user_configs_discord_id", "discord_id", unique=True),)
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    discord_id: Mapped[int] = mapped_column(BigInteger(), unique=True)
+    discord_id: Mapped[int] = mapped_column(UInt64Integer(), unique=True)
     synthesis_alt_jacket: Mapped[str] = mapped_column()
     privacy_mode: Mapped[bool] = mapped_column(
         default=False, server_default=text("FALSE")
@@ -35,7 +35,7 @@ class UserConfig(Base):
 class EasterEggFound(Base):
     __tablename__ = "easter_eggs_found"
 
-    discord_id: Mapped[int] = mapped_column(BigInteger())
+    discord_id: Mapped[int] = mapped_column(UInt64Integer())
     easter_egg: Mapped[str] = mapped_column()
 
     __table_args__ = (PrimaryKeyConstraint(discord_id, easter_egg),)
@@ -45,9 +45,9 @@ class CommandUse(Base):
     __tablename__ = "command_uses"
 
     id: Mapped[int] = mapped_column(primary_key=True)
-    guild_id: Mapped[int | None] = mapped_column(BigInteger())
-    channel_id: Mapped[int] = mapped_column(BigInteger())
-    author_id: Mapped[int] = mapped_column(BigInteger())
+    guild_id: Mapped[int | None] = mapped_column(UInt64Integer())
+    channel_id: Mapped[int] = mapped_column(UInt64Integer())
+    author_id: Mapped[int] = mapped_column(UInt64Integer())
     prefix: Mapped[str] = mapped_column()
     command: Mapped[str] = mapped_column()
     is_failure: Mapped[bool] = mapped_column()

--- a/chuni_penguin/ui/song_info.py
+++ b/chuni_penguin/ui/song_info.py
@@ -54,7 +54,7 @@ class SongInfoPageSource(ListPageSource[Song]):
                         [
                             escape_markdown(x.alias)
                             for x in song.aliases
-                            if x.guild_id == -1
+                            if x.guild_id == 0
                         ]
                     )
                     song_description += "\n"

--- a/dbutils/aliases.py
+++ b/dbutils/aliases.py
@@ -62,7 +62,7 @@ async def update_aliases(
 
             inserted_aliases.extend(
                 [
-                    {"alias": x, "guild_id": -1, "song_id": song.id, "owner_id": None}
+                    {"alias": x, "guild_id": 0, "song_id": song.id, "owner_id": None}
                     for x in alias[1:]
                 ]
             )


### PR DESCRIPTION
SQLite does not have an unsigned 64-bit integer type, which means that Discord identifiers stored in this bot will break around ~2084. I'm not sure if I, or CHUNITHM, or Discord will be around until then, but might as well be correct ¯\_(ツ)_/¯

The idea is that we bit cast the uint64 into an int64, so anything above 2**63 is represented as a negative number.

Currently nothing will change since we have about ~58 years until that is actually a problem.

Also includes a fix for negative identifiers we use in `aliases` and `guess_leaderboard`, though we only really depend on `aliases.guild_id == -1`.